### PR TITLE
Fix error in redBall demo config file

### DIFF
--- a/demoRedBall/CMakeLists.txt
+++ b/demoRedBall/CMakeLists.txt
@@ -31,5 +31,5 @@ file(GLOB conf ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/*.ini)
 file(GLOB scripts ${CMAKE_CURRENT_SOURCE_DIR}/app/scripts/*.template
                   ${CMAKE_CURRENT_SOURCE_DIR}/app/scripts/*.m)
 
-yarp_install(FILES ${conf}    DESTINATION ${ICUBCONTRIB_CONTEXTS_INSTALL_DIR}/${PROJECTNAME})
+yarp_install(FILES ${conf}    DESTINATION ${ICUBCONTRIB_CONTEXTS_INSTALL_DIR}/${PROJECT_NAME})
 yarp_install(FILES ${scripts} DESTINATION ${ICUBCONTRIB_APPLICATIONS_TEMPLATES_INSTALL_DIR})


### PR DESCRIPTION
fix installation of config.ini , wrong name of macro was used.
Change PROJECTNAME to PROJECT_NAME

Maybe other demo may have this issue