### PR TITLE
Python script to replace MATLAB script

### DIFF
--- a/pf3dTracker/CMakeLists.txt
+++ b/pf3dTracker/CMakeLists.txt
@@ -26,7 +26,7 @@ target_link_libraries(${PROJECT_NAME} ${OpenCV_LIBRARIES} ${YARP_LIBRARIES})
 install(TARGETS ${PROJECT_NAME} DESTINATION bin)
 
 if(NOT BUILD_BUNDLE)
-    icubcontrib_add_uninstall_target()
+  icubcontrib_add_uninstall_target()
 endif()
 
 # app
@@ -34,7 +34,8 @@ file(GLOB conf ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/*.ini
                ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/*.txt
                ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/*.csv)
 file(GLOB models ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/models/*.bmp
-                 ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/models/*.csv)
+                 ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/models/*.csv
+                 ${CMAKE_CURRENT_SOURCE_DIR}/app/conf/models/*.py)
 file(GLOB scripts ${CMAKE_CURRENT_SOURCE_DIR}/app/scripts/*.template)
 
 yarp_install(FILES ${conf}    DESTINATION ${ICUBCONTRIB_CONTEXTS_INSTALL_DIR}/${PROJECT_NAME})

--- a/pf3dTracker/app/conf/models/generate_shape_model.py
+++ b/pf3dTracker/app/conf/models/generate_shape_model.py
@@ -1,0 +1,55 @@
+# Copyright: (C) 2019 iCub Tech Facility - Istituto Italiano di Tecnologia
+# Authors: Ugo Pattacini <ugo.pattacini@iit.it>
+# CopyPolicy: Released under the terms of the GNU GPL v3.0.
+
+# This script generates the ball shape model
+# composed of initial estimates of its radius
+
+import argparse
+import math
+
+parser = argparse.ArgumentParser()
+parser.add_argument("-r", "--radius", type=float,
+                    help="ball radius in millimeters (default: 30)", default=30)
+parser.add_argument("-p", "--percentage", type=float,
+                    help="percentage in [0, 100] for inner and outer radii (default: 20)", default=20)
+parser.add_argument("-n", "--points", type=int,
+                    help="number of points generated (default: 50)", default=50)
+parser.add_argument("-f", "--file", type=str,
+                    help="name of the generated file (default: shape_model.csv)", default='shape_model.csv')
+args = parser.parse_args()
+
+print('using:')
+print('radius     = {} [mm]'.format(args.radius))
+print('percentage = {} [%]'.format(args.percentage))
+print('points     = {}'.format(args.points))
+print('file       = "{}"'.format(args.file))
+
+R_i = (1.0 - (args.percentage / 100.0)) * args.radius
+R_o = (1.0 + (args.percentage / 100.0)) * args.radius
+
+x = []
+y = []
+z = []
+t = 0.0
+t_delta = (2.0 * math.pi) / args.points
+for i in range(args.points):
+    x.append(0.0)
+    y.append(math.sin(t))
+    z.append(math.cos(t))
+    t += t_delta
+
+fout = open(args.file, "w")
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(x[i]))
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(x[i]))
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(R_i * y[i]))
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(R_o * y[i]))
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(R_i * z[i]))
+for i in range(args.points):
+    fout.write('{0:.3f}\n'.format(R_o * z[i]))
+fout.close()

--- a/pf3dTracker/matlab_files/README.md
+++ b/pf3dTracker/matlab_files/README.md
@@ -1,0 +1,2 @@
+#### :warning: This method has been superseded by [generate_shape_model.py](../app/conf/models/generate_shape_model.py).
+


### PR DESCRIPTION
This PR introduces a Python script that replaces the MATLAB script used to generate the ball shape model.

The script is located in `pf3dTracker/app/conf/models`.

#### Usage
```sh
$ python generate_shape_model --radius <R> --file <filename>
```
There's also available the option `--help`.
Then, the generated file needs to be pointed at from within the standard `pf3dTracker` configuration file.

cc @vtikha 