### PR TITLE
Fixed CI for MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
     - name: Dependencies [macOS]
       if: matrix.os == 'macOS-latest'
       run: |
+        brew unlink bazel
         brew update
         brew upgrade
         brew install ace cmake eigen gsl ipopt opencv pkg-config qt5


### PR DESCRIPTION
This PR fixes dependencies installation failures due to `bazel`.

cc @traversaro 