### PR TITLE
Drop deprecated mambaforge installer and use conda instead of mamba

### DIFF
--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -22,9 +22,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         channels: conda-forge,robotology
         channel-priority: true
@@ -35,9 +34,9 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
+        conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        mamba install yarp icub-main gazebo icub-contrib-common qt opencv
+        conda install yarp icub-main gazebo icub-contrib-common qt opencv
     
     # Additional dependencies useful only on Linux when using Qt
     - name: Dependencies [Conda/Linux]
@@ -46,7 +45,7 @@ jobs:
       run: |
         # Additional dependencies only useful on Linux
         # See https://github.com/robotology/robotology-superbuild/issues/477
-        mamba install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
+        conda install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 
 
     - name: Configure [Linux&macOS]


### PR DESCRIPTION
The `mambaforge` installer is now deprecated and is failing more and more frequently, and will stop working in 2025 (see https://github.com/conda-forge/miniforge?tab=readme-ov-file#should-i-choose-one-or-another-going-forward-at-the-risk-of-one-of-them-getting-deprecated), so we switch to just use `miniforge` .

On the other hand, `conda` is now as fast as `mamba` (see https://www.anaconda.com/blog/a-faster-conda-for-a-growing-community), so to simplify the CI script we can always use conda instead of alternating conda and mamba.