### PR TITLE
Update CI workflow to use Windows 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,6 @@ jobs:
                      -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
 
-        echo "${{ github.workspace }}/install/bin" >> $GITHUB_PATH
-        echo "${{ github.workspace }}/install/lib/yarp" >> $GITHUB_PATH
-        # Fix for using YARP idl generators (that link ACE) in Windows (https://github.com/robotology/idyntree/issues/569)
-        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
-          echo "${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin" >> $GITHUB_PATH
-        fi
-
         # icub-main
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
@@ -101,7 +94,7 @@ jobs:
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
                      -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
                      -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON \
-                     -DENABLE_icubmod_gazecontrollerclient=ON ..
+                     -DENABLE_icubmod_gazecontrollerclient=ON -DENABLE_icubmod_couplingICubHandMk2=OFF -DENABLE_icubmod_couplingICubEye=OFF..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         sudo apt update
         sudo apt install -y git build-essential pkg-config zip unzip zlib1g-dev cmake libace-dev coinor-libipopt-dev libeigen3-dev \
                             qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libtinyxml-dev libgsl-dev wget curl autoconf \
-                            autogen automake libtool mlocate libopencv-dev
+                            autogen automake libtool libopencv-dev
 
     - name: Source-based Dependencies [Windows] 
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,17 @@ jobs:
         git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
         cd yarp && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
+                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DYARP_COMPILE_GUIS:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
                      -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
+
+        echo "${{ github.workspace }}/install/bin" >> $GITHUB_PATH
+        echo "${{ github.workspace }}/install/lib/yarp" >> $GITHUB_PATH
+        # Fix for using YARP idl generators (that link ACE) in Windows (https://github.com/robotology/idyntree/issues/569)
+        if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+          echo "${VCPKG_INSTALLATION_ROOT}/installed/x64-windows/bin" >> $GITHUB_PATH
+        fi
+
         # icub-main
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
@@ -117,14 +125,14 @@ jobs:
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
         cd yarp && mkdir -p build && cd build
-        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DYARP_COMPILE_GUIS:BOOL=OFF -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-main
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
         cd icub-main && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-               -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON -DENABLE_icubmod_gazecontrollerclient=ON -DENABLE_icubmod_couplingICubHandMk2=OFF -DENABLE_icubmod_ENABLE_couplingICubEye=OFF ..
+               -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON -DENABLE_icubmod_gazecontrollerclient=ON ..
         cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
         # yarp
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/yarp.git --depth 1 --branch master
+        git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
         cd yarp && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
                      -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
@@ -115,7 +115,7 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target install 
         # yarp
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/yarp.git --depth 1 --branch master
+        git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
         cd yarp && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target install 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
                      -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
                      -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON \
-                     -DENABLE_icubmod_gazecontrollerclient=ON -DENABLE_icubmod_couplingICubHandMk2=OFF -DENABLE_icubmod_couplingICubEye=OFF..
+                     -DENABLE_icubmod_gazecontrollerclient=ON -DENABLE_icubmod_couplingICubHandMk2=OFF -DENABLE_icubmod_couplingICubEye=OFF ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
         cd icub-main && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-               -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON -DENABLE_icubmod_gazecontrollerclient=ON ..
+               -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON -DENABLE_icubmod_gazecontrollerclient=ON -DENABLE_icubmod_couplingICubHandMk2=OFF -DENABLE_icubmod_ENABLE_couplingICubEye=OFF ..
         cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ on:
   pull_request:
   schedule:
   # * is a special character in YAML so you have to quote this string
-  # Execute a "nightly" build at 2 AM UTC 
+  # Execute a "nightly" build at 2 AM UTC
   - cron:  '0 2 * * *'
   workflow_dispatch:
-    
+
 jobs:
   build:
     name: '[${{ matrix.os }}@${{ matrix.build_type }}]'
@@ -20,19 +20,19 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-2022, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@main
-        
+
     - name: Set up environment variables [Windows]
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       shell: bash
       run: |
         # the following fix the problem described in https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/m-p/43839#M5530
         echo "C:\Program Files\Git\bin" >> ${GITHUB_PATH}
         echo "VCPKG_ROBOTOLOGY_ROOT=C:/robotology/vcpkg" >> ${GITHUB_ENV}
-        
+
     - name: Display environment variables
       shell: bash
       run: env
@@ -48,7 +48,7 @@ jobs:
     # DEPENDENCIES
     # ============
     - name: Dependencies [Windows]
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       shell: bash
       run: |
         choco install -y curl wget unzip
@@ -67,8 +67,8 @@ jobs:
                             qtbase5-dev qtdeclarative5-dev qtmultimedia5-dev libtinyxml-dev libgsl-dev wget curl autoconf \
                             autogen automake libtool libopencv-dev
 
-    - name: Source-based Dependencies [Windows] 
-      if: matrix.os == 'windows-latest'
+    - name: Source-based Dependencies [Windows]
+      if: matrix.os == 'windows-2022'
       shell: bash
       run: |
         # ycm
@@ -77,7 +77,7 @@ jobs:
         cd ycm && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
                      -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
+        cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # yarp
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
@@ -88,21 +88,21 @@ jobs:
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-main
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/icub-main.git --depth 1 --branch devel
+        git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
         cd icub-main && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
                      -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
                      -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON \
                      -DENABLE_icubmod_gazecontrollerclient=ON ..
-        cmake --build . --config ${{ matrix.build_type }} --target INSTALL 
+        cmake --build . --config ${{ matrix.build_type }} --target INSTALL
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/icub-contrib-common.git --depth 1
         cd icub-contrib-common && mkdir -p build && cd build
         cmake -A x64 -DCMAKE_TOOLCHAIN_FILE=${VCPKG_ROBOTOLOGY_ROOT}/scripts/buildsystems/vcpkg.cmake \
-                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..        
+                     -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
         cmake --build . --config ${{ matrix.build_type }} --target INSTALL
-        
+
     - name: Source-based Dependencies [Ubuntu]
       if: matrix.os == 'ubuntu-latest'
       shell: bash
@@ -112,26 +112,26 @@ jobs:
         git clone https://github.com/robotology/ycm.git --depth 1 --branch master
         cd ycm && mkdir -p build && cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }} --target install 
+        cmake --build . --config ${{ matrix.build_type }} --target install
         # yarp
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/yarp.git --depth 1 --branch yarp-3.12
         cd yarp && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }} --target install 
+        cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-main
         cd ${GITHUB_WORKSPACE}
-        git clone https://github.com/robotology/icub-main.git --depth 1 --branch devel
+        git clone https://github.com/robotology/icub-main.git --depth 1 --branch master
         cd icub-main && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
                -DENABLE_icubmod_cartesiancontrollerserver=ON -DENABLE_icubmod_cartesiancontrollerclient=ON -DENABLE_icubmod_gazecontrollerclient=ON ..
-        cmake --build . --config ${{ matrix.build_type }} --target install 
+        cmake --build . --config ${{ matrix.build_type }} --target install
         # icub-contrib-common
         cd ${GITHUB_WORKSPACE}
         git clone https://github.com/robotology/icub-contrib-common.git --depth 1
         cd icub-contrib-common && mkdir -p build && cd build
         cmake  -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
-        cmake --build . --config ${{ matrix.build_type }} --target install 
+        cmake --build . --config ${{ matrix.build_type }} --target install
       env:
         # This is necessary only on macOS/homebrew, but on Linux it should be ignored
         Qt5_DIR: /usr/local/opt/qt5/lib/cmake/Qt5
@@ -139,7 +139,7 @@ jobs:
     # CMAKE-BASED PROJECT
     # ===================
     - name: Configure [Windows]
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-2022'
       shell: bash
       run: |
         mkdir -p build
@@ -153,22 +153,22 @@ jobs:
       shell: bash
       run: |
         mkdir -p build
-        cd build    
+        cd build
         cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
       env:
         # This is necessary only on macOS/homebrew, but on Linux it should be ignored
         Qt5_DIR: /usr/local/opt/qt5/lib/cmake/Qt5
-      
+
     - name: Build
       shell: bash
       run: |
         cd build
-        # Fix for using YARP idl generators (that link ACE) in Windows 
+        # Fix for using YARP idl generators (that link ACE) in Windows
         # See https://github.com/robotology/idyntree/issues/569 for more details
         export PATH=$PATH:${GITHUB_WORKSPACE}/install/bin:${VCPKG_ROBOTOLOGY_ROOT}/installed/x64-windows/bin
         cmake --build . --config ${{ matrix.build_type }}
-        
+
     - name: Install
       shell: bash
       run: |

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -32,6 +32,7 @@ jobs:
       shell: bash -l {0}
       run: |
         # Compilation related dependencies
+        conda update -n base -c defaults conda
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main gazebo icub-contrib-common qt opencv

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -35,7 +35,7 @@ jobs:
         conda update -n base -c defaults conda
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install yarp icub-main icub-contrib-common qt opencv
+        conda install yarp icub-main icub-contrib-common "qt6-main>=6.7.2" "libopencv>=4.10.0"
         # See https://github.com/robotology/robotology-superbuild/issues/477
         conda install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -34,7 +34,7 @@ jobs:
         # Compilation related dependencies
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install yarp icub-main gazebo icub-contrib-common qt opencv opencv-contrib
+        conda install yarp icub-main gazebo icub-contrib-common qt opencv
     
     # Additional dependencies useful only on Linux when using Qt
     - name: Dependencies [Conda/Linux]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -36,8 +36,6 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main icub-contrib-common "qt6-main>=6.7.2" "libopencv>=4.10.0"
-        # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 
 
     - name: Configure [Linux]
@@ -46,7 +44,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -GNinja -DBUILD_TESTING:BOOL=ON \
+        cmake -GNinja \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Configure [Windows]
@@ -55,7 +53,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON \
+        cmake -G"Visual Studio 17 2022" \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build
@@ -64,8 +62,8 @@ jobs:
         cd build
         cmake --build . --config ${{ matrix.build_type }}
 
-    - name: Test
-      shell: bash -l {0}
+    - name: Install
+      shell: bash
       run: |
         cd build
-        ctest --output-on-failure -C ${{ matrix.build_type }}
+        cmake --build . --config ${{ matrix.build_type }} --target install

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -35,7 +35,7 @@ jobs:
         conda update -n base -c defaults conda
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install yarp icub-main gazebo icub-contrib-common qt opencv
+        conda install yarp icub-main icub-contrib-common qt opencv
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-version: latest
+        miniforge-variant: Miniforge3
         channels: conda-forge,robotology
         channel-priority: true
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -36,9 +36,12 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main icub-contrib-common qt opencv
+        # See https://github.com/robotology/robotology-superbuild/issues/477
+        conda install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
 
-    - name: Configure [Linux&macOS]
-      if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')
+
+    - name: Configure [Linux]
+      if: contains(matrix.os, 'ubuntu')
       shell: bash -l {0}
       run: |
         mkdir -p build

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -35,16 +35,6 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main gazebo icub-contrib-common qt opencv
-    
-    # Additional dependencies useful only on Linux when using Qt
-    - name: Dependencies [Conda/Linux]
-      if: contains(matrix.os, 'ubuntu') 
-      shell: bash -l {0}
-      run: |
-        # Additional dependencies only useful on Linux
-        # See https://github.com/robotology/robotology-superbuild/issues/477
-        conda install expat-cos7-x86_64 libselinux-cos7-x86_64 libxau-cos7-x86_64 libxcb-cos7-x86_64 libxdamage-cos7-x86_64 libxext-cos7-x86_64 libxfixes-cos7-x86_64 libxxf86vm-cos7-x86_64 mesa-libgl-devel-cos7-x86_64 libxshmfence-cos7-x86_64 libxshmfence-devel-cos7-x86_64
-
 
     - name: Configure [Linux&macOS]
       if: contains(matrix.os, 'macos') || contains(matrix.os, 'ubuntu')

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -61,7 +61,7 @@ jobs:
       run: |
         mkdir -p build
         cd build
-        cmake -G"Visual Studio 16 2019" -DBUILD_TESTING:BOOL=ON \
+        cmake -G"Visual Studio 17 2022" -DBUILD_TESTING:BOOL=ON \
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -36,6 +36,12 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main icub-contrib-common "qt6-main>=6.7.2" "libopencv>=4.10.0"
+
+
+    - name: Install mesa deps under linux [Linux]
+      if: contains(matrix.os, 'ubuntu')
+      shell: bash -l {0}
+      run: |
         # See https://github.com/robotology/robotology-superbuild/issues/477
         conda install mesa-libgl-devel-cos7-x86_64
 

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -31,8 +31,6 @@ jobs:
     - name: Dependencies
       shell: bash -l {0}
       run: |
-        # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
-        conda config --remove channels defaults
         # Compilation related dependencies
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -36,6 +36,8 @@ jobs:
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
         conda install yarp icub-main icub-contrib-common "qt6-main>=6.7.2" "libopencv>=4.10.0"
+        # See https://github.com/robotology/robotology-superbuild/issues/477
+        conda install mesa-libgl-devel-cos7-x86_64
 
 
     - name: Configure [Linux]

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         build_type: [Release]
-        os: [ubuntu-latest, windows-2019, macos-latest]
+        os: [ubuntu-latest, windows-2022]
       fail-fast: false
 
     steps:

--- a/.github/workflows/conda-ci.yml
+++ b/.github/workflows/conda-ci.yml
@@ -34,7 +34,7 @@ jobs:
         # Compilation related dependencies
         conda install cmake compilers make ninja pkg-config
         # Actual dependencies
-        conda install yarp icub-main gazebo icub-contrib-common qt opencv
+        conda install yarp icub-main gazebo icub-contrib-common qt opencv opencv-contrib
     
     # Additional dependencies useful only on Linux when using Qt
     - name: Dependencies [Conda/Linux]


### PR DESCRIPTION
This is because in June 2025 the windows-2019 runners have been deprecated, they will start soon to be dismissed